### PR TITLE
Add SCRAPERWIKI_DATABASE_NAME env var

### DIFF
--- a/scraperwiki/sqlite.py
+++ b/scraperwiki/sqlite.py
@@ -3,7 +3,9 @@ import datetime
 import re
 import os
 
-def _connect(dbname = 'scraperwiki.sqlite'):
+DATABASE_NAME = os.environ.get("SCRAPERWIKI_DATABASE_NAME", "scraperwiki.sqlite")
+
+def _connect(dbname = DATABASE_NAME):
   'Initialize the database (again). This is mainly for testing'
   global dt
   dt = DumpTruck(dbname = dbname,  adapt_and_convert = False)


### PR DESCRIPTION
In another tool we are writing tests which really want to me `:memory:`
databases so that they are fresh each time. The easiest way to achieve this
seems to be to have an environment variable.
