### PR TITLE
Clarify setup.py warning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,9 @@ def has_external_dependency(name):
 
 if not has_external_dependency('pdftohtml'):
     warnings.warn(
-        'Local Scraperlibs requires pdftohtml, but pdftohtml was not found\n'
-        'in the PATH. You probably need to install it.'
+        'scraperwiki.pdftoxml requires pdftohtml, but pdftohtml was not found\n'
+        'in the PATH. If you wish to use this function, you probably need to\n'
+        'install pdftohtml.'
     )
 
 config = dict(name='scraperwiki',


### PR DESCRIPTION
A Stack Overflow user [was confused by this warning](http://stackoverflow.com/questions/23674904/installing-scraperwiki-for-python-generates-an-error-pdftohtml-not-found). It's not clear if they even want to use `scraperwiki.pdftoxml`, which is the only reason to install `pdftohtml`.
