### PR TITLE
Allow pdftoxml to accept options.

### DIFF
--- a/scraperwiki/utils.py
+++ b/scraperwiki/utils.py
@@ -38,7 +38,7 @@ def scrape(url, params=None, user_agent=None):
     return text
 
 
-def pdftoxml(pdfdata):
+def pdftoxml(pdfdata, options=""):
     """converts pdf file to xml file"""
     pdffout = tempfile.NamedTemporaryFile(suffix='.pdf')
     pdffout.write(pdfdata)
@@ -46,8 +46,8 @@ def pdftoxml(pdfdata):
 
     xmlin = tempfile.NamedTemporaryFile(mode='r', suffix='.xml')
     tmpxml = xmlin.name  # "temph.xml"
-    cmd = 'pdftohtml -xml -nodrm -zoom 1.5 -enc UTF-8 -noframes "%s" "%s"' % (
-        pdffout.name, os.path.splitext(tmpxml)[0])
+    cmd = 'pdftohtml -xml -nodrm -zoom 1.5 -enc UTF-8 -noframes %s "%s" "%s"' % (
+        options, pdffout.name, os.path.splitext(tmpxml)[0])
     # can't turn off output, so throw away even stderr yeuch
     cmd = cmd + " >/dev/null 2>&1"
     os.system(cmd)


### PR DESCRIPTION
The version of pdftoxml on the old scraperwiki site accepted extra options
in the second argument.  This patch add the same argument to this version
of pdftoxml, to allow the -hidden flag to be added when needed.
