### PR TITLE
Add exceptions scraperwiki.CPUTimeExceededError and scraperwiki.Error.

### DIFF
--- a/scraperwiki/__init__.py
+++ b/scraperwiki/__init__.py
@@ -12,3 +12,12 @@ import sql
 
 # Compatibility
 sqlite = sql
+
+class Error(Exception):
+    """All ScraperWiki exceptions are instances of this class
+    (usually via a subclass)."""
+    pass
+
+class CPUTimeExceededError(Error):
+    """CPU time limit exceeded."""
+    pass


### PR DESCRIPTION
This bring the library closer to the classic API, which provided
both these exceptions.
