### PR TITLE
Always return unicode strings from pdftoxml.

### DIFF
--- a/scraperwiki/utils.py
+++ b/scraperwiki/utils.py
@@ -56,7 +56,7 @@ def pdftoxml(pdfdata, options=""):
     #xmlfin = open(tmpxml)
     xmldata = xmlin.read()
     xmlin.close()
-    return xmldata
+    return xmldata.decode('utf-8')
 
 
 def _in_box():


### PR DESCRIPTION
The pdftoxml method on the old scraperwiki site returned
unicode strings.  Change this version to do the same by
interpreting the byte stream from pdftohtml as UTF-8.

Fixes issue #38
